### PR TITLE
Bump molecule from 3.0.6 to 3.2.3

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,7 +1,7 @@
 ansible
 ansible-lint
-docker-py
 molecule
+molecule-docker
 pytest-socket
 pytest-testinfra
 python-jenkins

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,6 @@ ansible==2.9.11
     # via
     #   -r requirements-dev.in
     #   ansible-lint
-    #   molecule
 arrow==0.15.8
     # via jinja2-time
 attrs==19.3.0
@@ -42,11 +41,10 @@ click==7.1.2
     #   click-help-colors
     #   cookiecutter
     #   molecule
-    #   python-gilt
 colorama==0.4.3
-    # via
-    #   molecule
-    #   python-gilt
+    # via rich
+commonmark==0.9.1
+    # via rich
 cookiecutter==1.7.2
     # via molecule
 cryptography==3.0
@@ -55,12 +53,10 @@ cryptography==3.0
     #   paramiko
 distro==1.5.0
     # via selinux
-docker-py==1.10.6
-    # via -r requirements-dev.in
-docker-pycreds==0.4.0
-    # via docker-py
-fasteners==0.15
-    # via python-gilt
+docker==4.4.3
+    # via molecule-docker
+enrich==1.2.6
+    # via molecule
 idna==2.10
     # via requests
 iniconfig==1.0.0
@@ -78,36 +74,38 @@ markupsafe==1.1.1
     # via
     #   cookiecutter
     #   jinja2
-molecule==3.0.6
+molecule-docker==0.2.4
     # via -r requirements-dev.in
-monotonic==1.5
-    # via fasteners
+molecule==3.2.3
+    # via
+    #   -r requirements-dev.in
+    #   molecule-docker
 more-itertools==8.4.0
     # via pytest
 multi-key-dict==2.0.3
     # via python-jenkins
 packaging==20.4
-    # via pytest
+    # via
+    #   molecule
+    #   pytest
 paramiko==2.7.1
     # via molecule
 pathspec==0.8.0
     # via yamllint
 pbr==5.4.5
     # via python-jenkins
-pexpect==4.8.0
-    # via molecule
 pluggy==0.13.1
     # via
     #   molecule
     #   pytest
 poyo==0.5.0
     # via cookiecutter
-ptyprocess==0.6.0
-    # via pexpect
 py==1.9.0
     # via pytest
 pycparser==2.20
     # via cffi
+pygments==2.8.0
+    # via rich
 pynacl==1.4.0
     # via paramiko
 pyparsing==2.4.7
@@ -122,8 +120,6 @@ pytest==6.0.1
     #   pytest-testinfra
 python-dateutil==2.8.1
     # via arrow
-python-gilt==1.2.3
-    # via molecule
 python-jenkins==1.7.0
     # via -r requirements-dev.in
 python-slugify==4.0.1
@@ -133,23 +129,24 @@ pyyaml==5.3.1
     #   ansible
     #   ansible-lint
     #   molecule
-    #   python-gilt
     #   yamllint
 requests==2.24.0
     # via
     #   cookiecutter
-    #   docker-py
+    #   docker
     #   python-jenkins
+rich==9.11.1
+    # via
+    #   enrich
+    #   molecule
 ruamel.yaml.clib==0.2.2
     # via ruamel.yaml
 ruamel.yaml==0.16.10
     # via ansible-lint
 selinux==0.2.1
-    # via molecule
-sh==1.13.1
     # via
     #   molecule
-    #   python-gilt
+    #   molecule-docker
 shellingham==1.3.2
     # via click-completion
 six==1.15.0
@@ -158,26 +155,24 @@ six==1.15.0
     #   click-completion
     #   cookiecutter
     #   cryptography
-    #   docker-py
-    #   docker-pycreds
-    #   fasteners
+    #   docker
     #   packaging
     #   pynacl
     #   python-dateutil
     #   python-jenkins
     #   websocket-client
-tabulate==0.8.7
+subprocess-tee==0.2.0
     # via molecule
 text-unidecode==1.3
     # via python-slugify
 toml==0.10.1
     # via pytest
-tree-format==0.1.2
-    # via molecule
+typing-extensions==3.7.4.3
+    # via rich
 urllib3==1.25.10
     # via requests
 websocket-client==0.57.0
-    # via docker-py
+    # via docker
 yamllint==1.24.2
     # via molecule
 


### PR DESCRIPTION
As of molecule 3.2.x, the molecule-docker package is needed in order
to use the `docker` driver in `molecule.yml`. This replaces the
`docker-py` package, which must be removed in order to avoid
conflicts.
