### PR TITLE
Suppress no-handler violation from ansible-lint

### DIFF
--- a/tasks/stop-service.yml
+++ b/tasks/stop-service.yml
@@ -12,7 +12,7 @@
   # https://github.com/ansible-community/molecule/issues/2765
   changed_when: false
 
-- name: Wait for Jenkins to stop
+- name: Wait for Jenkins to stop  # noqa: no-handler
   wait_for:
     timeout: 5
   when: jenkins_service_stop is changed


### PR DESCRIPTION
Using a handler here would unnecessarily increase the complexity of
the code. Because we need to make sure the serivce is stopped
immediately (this tasks file is sometimes included via
`include_role`/`tasks_from`), we'd need to flush the handlers
immediately.
