### PR TITLE
Minor improvements to required plugin handling

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -91,6 +91,11 @@ def test_jenkins_plugins():
     controller = Jenkins("http://localhost:8100")
     plugins = controller.get_plugins()
 
+    # Assert that JCasC itself could be loaded. It is possible that other plugins could
+    # load, but if something is wrong with JCasC itself, we're in trouble.
+    assert plugins["configuration-as-code"]["active"]
+    assert plugins["configuration-as-code"]["enabled"]
+    # Assert that our custom plugin was also installed and is running.
     assert plugins["sidebar-link"]["active"]
     assert plugins["sidebar-link"]["enabled"]
     # The sidebar-link plugin has an implied dependency on structs, which is not specified

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -10,7 +10,6 @@ repositories {
 
 dependencies {
   implementation 'io.jenkins:configuration-as-code:1.53'
-  implementation 'io.jenkins.plugins:snakeyaml-api:1.29.1'
 }
 
 task getDeps(type: Copy) {


### PR DESCRIPTION
- Remove snakeyaml-api plugin from pom.xml
- Assert that JCasC was installed and is running

I made these improvements while trying to fix some other issues related to
updating to JCasC 1.54.
