### PR TITLE
Lint role meta files

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -2,7 +2,6 @@
 exclude_paths:
   - .ansible/roles
   - .venv
-  - meta
   - molecule
 parseable: true
 skip_list:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Installs the Jenkins CI service with JCasC
   company: Ableton AG
   license: MIT
-  min_ansible_version: 2.9
+  min_ansible_version: 2.10
   role_name: jenkins_jcasc
 
   galaxy_tags:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Installs the Jenkins CI service with JCasC
   company: Ableton AG
   license: MIT
-  min_ansible_version: 2.10
+  min_ansible_version: "2.10"
   role_name: jenkins_jcasc
 
   galaxy_tags:


### PR DESCRIPTION
We have previously avoided linting these files, but ansible-lint 6.2.x has some useful features for them, so we should no longer skip them.