### PR TITLE
Apply loose versioning to JCasC package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,11 @@
   "constraints": {"python": "3.10.6"},
   "extends": ["config:base"],
   "enabledManagers": ["ansible-galaxy", "gradle", "pip-compile"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["io.jenkins:configuration-as-code"],
+      "versioning": "loose"
+    }
+  ],
   "pip-compile": {"fileMatch": ["^requirements-dev\\.in$"]}
 }


### PR DESCRIPTION
Because of the new non-semantic versioning scheme used by Jenkins
plugins, renovate has a hard time identifying new versions. To get
around this, we must tell renovate to use loose versioning.
