### PR TITLE
Allow role to be run without a global `become`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ and optional role variables.
 Example Playbook
 ----------------
 
-This role requires `root` permissions for several tasks, so `become: true` must be applied
-either to the playbook, or to the individual role (as shown below).
-
 ```yaml
 ---
 - name: Provision Jenkins
@@ -65,7 +62,7 @@ either to the playbook, or to the individual role (as shown below).
     jenkins_jobs_dir: "{{ playbook_dir }}/files/jenkins/jobs"
 
   roles:
-    - {role: ableton.jenkins_jcasc, become: true}
+    - ableton.jenkins_jcasc
 ```
 
 HTTPS

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -5,7 +5,7 @@ FROM {{ item.image }}
 {% endif %}
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates gnupg python3 python3-apt sudo && \
+    apt-get install -y acl ca-certificates gnupg python3 python3-apt sudo && \
     apt-get clean
 
 RUN useradd -G sudo molecule

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -8,4 +8,11 @@ RUN apt-get update && \
     apt-get install -y acl ca-certificates gnupg python3 python3-apt sudo && \
     apt-get clean
 
-RUN useradd -G sudo molecule
+ENV ANSIBLE_USER=molecule ANSIBLE_GROUP=molecule
+ENV SUDO_GROUP=sudo
+RUN set -xe \
+  && groupadd -r ${ANSIBLE_GROUP} \
+  && useradd -m -g ${ANSIBLE_GROUP} ${ANSIBLE_USER} \
+  && usermod -aG ${SUDO_GROUP} ${ANSIBLE_USER} \
+  && usermod -aG ${ANSIBLE_GROUP} ${ANSIBLE_USER} \
+  && sed -i "/^%${SUDO_GROUP}/s/ALL\$/NOPASSWD:ALL/g" /etc/sudoers

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,6 +2,7 @@
 - name: Converge
   hosts: all
   vars:
+    ansible_user: "molecule"
     jenkins_custom_files:
       - src: "{{ playbook_dir }}/files/sidebar-link.xml"
         dest: "sidebar-link.xml"

--- a/tasks/configure-dirs.yml
+++ b/tasks/configure-dirs.yml
@@ -1,5 +1,6 @@
 ---
 - name: Ensure that Jenkins directories exist
+  become: true
   ansible.builtin.file:
     path: "{{ jenkins_dir }}"
     owner: "{{ jenkins_user }}"
@@ -18,6 +19,7 @@
     loop_var: jenkins_dir
 
 - name: Ensure that Jenkins secrets directory exists
+  become: true
   ansible.builtin.file:
     path: "{{ jenkins_secrets_dir }}"
     owner: "{{ jenkins_user }}"

--- a/tasks/configure-files.yml
+++ b/tasks/configure-files.yml
@@ -1,5 +1,6 @@
 ---
 - name: Configure JCasC configuration file
+  become: true
   ansible.builtin.template:
     src: "{{ jenkins_jcasc_config_file }}"
     dest: "{{ jenkins_config_dir }}/jenkins.yaml"
@@ -8,6 +9,7 @@
     mode: "0644"
 
 - name: Create intermediate dirs for custom files
+  become: true
   ansible.builtin.file:
     path: "{{ jenkins_home }}/{{ custom_file.dest | dirname }}"
     owner: "{{ jenkins_user }}"
@@ -19,6 +21,7 @@
     loop_var: custom_file
 
 - name: Configure custom files
+  become: true
   ansible.builtin.template:
     src: "{{ custom_file.src }}"
     dest: "{{ jenkins_home }}/{{ custom_file.dest }}"
@@ -30,6 +33,7 @@
     loop_var: custom_file
 
 - name: Copy secrets
+  become: true
   ansible.builtin.copy:
     src: "{{ secret_file }}"
     dest: "{{ jenkins_secrets_dir }}"
@@ -41,6 +45,7 @@
     loop_var: secret_file
 
 - name: Copy userContent
+  become: true
   ansible.builtin.copy:
     src: "{{ jenkins_user_content }}/"
     dest: "{{ jenkins_user_content_dir }}/"

--- a/tasks/configure-jobs.yml
+++ b/tasks/configure-jobs.yml
@@ -1,5 +1,6 @@
 ---
 - name: Job directories are present
+  become: true
   ansible.builtin.file:
     path: "{{ jenkins_home }}/jobs/{{ job_name }}"
     owner: "{{ jenkins_user }}"
@@ -11,6 +12,7 @@
     loop_var: job_name
 
 - name: Jobs are present
+  become: true
   ansible.builtin.copy:
     src: "{{ jenkins_jobs_dir }}/{{ job_name }}/config.xml"
     dest: "{{ jenkins_home }}/jobs/{{ job_name }}/config.xml"

--- a/tasks/configure-service-systemd.yml
+++ b/tasks/configure-service-systemd.yml
@@ -1,11 +1,13 @@
 ---
 - name: Generate Jenkins systemd service file
+  become: true
   ansible.builtin.template:
     src: "jenkins.service.j2"
     dest: "/etc/systemd/system/jenkins.service"
     mode: "0644"
 
 - name: Ensure systemd service runs at boot
+  become: true
   ansible.builtin.systemd:
     name: "jenkins"
     enabled: true

--- a/tasks/configure-service-sysvinit.yml
+++ b/tasks/configure-service-sysvinit.yml
@@ -1,5 +1,6 @@
 ---
 - name: Generate Jenkins launcher script
+  become: true
   ansible.builtin.template:
     src: "jenkins-sysvinit.sh.j2"
     dest: "/etc/init.d/jenkins"
@@ -8,6 +9,7 @@
     mode: "0755"
 
 - name: Install Jenkins service
+  become: true
   ansible.builtin.sysvinit:
     name: "jenkins"
     enabled: true

--- a/tasks/configure-user.yml
+++ b/tasks/configure-user.yml
@@ -1,10 +1,12 @@
 ---
 - name: Create Jenkins group
+  become: true
   ansible.builtin.group:
     name: "{{ jenkins_group }}"
     state: present
 
 - name: Create Jenkins user
+  become: true
   ansible.builtin.user:
     name: "{{ jenkins_user }}"
     group: "{{ jenkins_group }}"

--- a/tasks/install-java-apt.yml
+++ b/tasks/install-java-apt.yml
@@ -1,11 +1,13 @@
 ---
 - name: Ensure Java is installed
+  become: true
   ansible.builtin.apt:
     name: "{{ jenkins_java_package }}"
     state: present
     update_cache: true
 
 - name: Ensure daemon is installed
+  become: true
   ansible.builtin.apt:
     name: "daemon"
     state: present

--- a/tasks/install-jenkins.yml
+++ b/tasks/install-jenkins.yml
@@ -7,6 +7,8 @@
     dest: "{{ jenkins_war }}"
     # Sometimes the main Jenkins repository has network stability issues
     timeout: "{{ jenkins_download_timeout }}"
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
     mode: "0644"
   retries: "{{ jenkins_download_retries }}"
   delay: "{{ jenkins_download_delay }}"

--- a/tasks/install-jenkins.yml
+++ b/tasks/install-jenkins.yml
@@ -1,5 +1,6 @@
 ---
 - name: Download Jenkins WAR file
+  become: true
   ansible.builtin.get_url:
     url: "https://mirrors.jenkins.io/war-stable/{{ jenkins_version }}/jenkins.war"
     checksum: "sha256:\

--- a/tasks/install-pimt.yml
+++ b/tasks/install-pimt.yml
@@ -6,6 +6,7 @@
     jenkins_pimt_path: "{{ jenkins_lib_dir }}/{{ jenkins_pimt_jar }}"
 
 - name: Ensure that Jenkins Plugin Installation Manager Tool is installed
+  become: true
   ansible.builtin.get_url:
     url: "{{ jenkins_pimt_url }}"
     dest: "{{ jenkins_pimt_path }}"

--- a/tasks/install-pimt.yml
+++ b/tasks/install-pimt.yml
@@ -9,6 +9,8 @@
   ansible.builtin.get_url:
     url: "{{ jenkins_pimt_url }}"
     dest: "{{ jenkins_pimt_path }}"
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
     mode: "0644"
     timeout: "{{ jenkins_download_timeout }}"
   register: pimt_download_result

--- a/tasks/install-plugins.yml
+++ b/tasks/install-plugins.yml
@@ -9,16 +9,6 @@
   diff: "{{ jenkins_show_plugins_yaml_changes }}"
   register: copy_plugins_yaml_file
 
-# Remove the plugins directory before installing plugins to avoid potential problems with
-# conflicting dependencies, and also to correctly handle the case when plugins are removed
-# from the plugins.yaml file. PIMT has a `--clean-download-directory` argument, but we
-# can't use it because it'll fail to remove the directory.
-- name: Clean plugins directory
-  ansible.builtin.file:
-    path: "{{ jenkins_plugins_dir }}"
-    state: absent
-  when: copy_plugins_yaml_file is changed  # noqa no-handler
-
 - name: Install plugins
   when: copy_plugins_yaml_file is changed  # noqa no-handler
   block:
@@ -26,6 +16,15 @@
       ansible.builtin.set_fact:
         jenkins_pimt_log_output_to_file: true
       when: jenkins_pimt_logfile != ''
+
+    # Remove the plugins directory before installing plugins to avoid potential problems
+    # with conflicting dependencies, and also to correctly handle the case when plugins
+    # are removed from the plugins.yaml file. PIMT has a `--clean-download-directory`
+    # argument, but we can't use it because it'll fail to remove the directory.
+    - name: Clean plugins directory
+      ansible.builtin.file:
+        path: "{{ jenkins_plugins_dir }}"
+        state: absent
 
     - name: Use PIMT to install plugins
       become: true

--- a/tasks/install-plugins.yml
+++ b/tasks/install-plugins.yml
@@ -67,6 +67,9 @@
         path: "{{ jenkins_config_dir }}/plugins.yaml"
         line: "# Added by Ansible: PIMT failed on last run!"
         insertbefore: BOF
+        owner: "{{ jenkins_user }}"
+        group: "{{ jenkins_group }}"
+        mode: "0644"
 
     - name: Force the play to fail
       ansible.builtin.fail:

--- a/tasks/install-plugins.yml
+++ b/tasks/install-plugins.yml
@@ -1,5 +1,6 @@
 ---
 - name: Copy plugins file
+  become: true
   ansible.builtin.template:
     src: "{{ jenkins_plugins_file }}"
     dest: "{{ jenkins_config_dir }}/plugins.yaml"
@@ -22,6 +23,7 @@
     # are removed from the plugins.yaml file. PIMT has a `--clean-download-directory`
     # argument, but we can't use it because it'll fail to remove the directory.
     - name: Clean plugins directory
+      become: true
       ansible.builtin.file:
         path: "{{ jenkins_plugins_dir }}"
         state: absent
@@ -63,6 +65,7 @@
     # is run again, we need to ensure that PIMT will also be re-run. To do so, we alter
     # the plugins.yaml file, which will ensure that the template task will change it.
     - name: Write failure comment to plugins.yaml file
+      become: true
       ansible.builtin.lineinfile:
         path: "{{ jenkins_config_dir }}/plugins.yaml"
         line: "# Added by Ansible: PIMT failed on last run!"
@@ -81,6 +84,7 @@
 # manager tool. This allows us to ensure that these plugins are not overridden by a
 # different and possibly conflicting version.
 - name: Install custom Jenkins plugins
+  become: true
   ansible.builtin.copy:
     src: "{{ plugin_file }}"
     dest: "{{ jenkins_plugins_dir }}"

--- a/tasks/install-plugins.yml
+++ b/tasks/install-plugins.yml
@@ -9,9 +9,10 @@
   diff: "{{ jenkins_show_plugins_yaml_changes }}"
   register: copy_plugins_yaml_file
 
-# If the template file changed, then nuke the plugins directory before installing plugins.
-# We want to make sure to avoid any potential problems with conflicting dependencies, and
-# also to correctly handle the case when plugins are removed from the plugins.yaml file.
+# Remove the plugins directory before installing plugins to avoid potential problems with
+# conflicting dependencies, and also to correctly handle the case when plugins are removed
+# from the plugins.yaml file. PIMT has a `--clean-download-directory` argument, but we
+# can't use it because it'll fail to remove the directory.
 - name: Clean plugins directory
   ansible.builtin.file:
     path: "{{ jenkins_plugins_dir }}"

--- a/tasks/start-service.yml
+++ b/tasks/start-service.yml
@@ -1,5 +1,6 @@
 ---
 - name: Start Jenkins service
+  become: true
   ansible.builtin.service:
     name: "jenkins"
     state: started


### PR DESCRIPTION
This PR adds `become: true` to those tasks that require it, and also changes our Molecule converge playbook to run as an unprivileged user. Note that this PR lacks a version bump, which is intentional. I am also working on changing the PIMT logging output option, which will be a breaking change. This change, although not breaking, should be released with a minor version bump so that we can draw attention to the new behavior.