### PR TITLE
Update ableton-utils to 0.24.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library(identifier: 'ableton-utils@0.23', changelog: false)
+library(identifier: 'ableton-utils@0.24', changelog: false)
 library(identifier: 'groovylint@0.13', changelog: false)
 library(identifier: 'python-utils@0.13', changelog: false)
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -32,4 +32,4 @@
     jenkins_user_content: "{{ playbook_dir }}/files/userContent"
     jenkins_version: "2.346.3"
   roles:
-    - ansible-role-jenkins-jcasc
+    - ableton.jenkins_jcasc


### PR DESCRIPTION
This update contains some improvements with how Ansible roles are tested with Molecule that will allow us to remove some of our hacks regarding role naming in the Molecule configuration files.