### PR TITLE
Remove dependency pins from requirements-dev.in

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,4 @@
-ansible-core==2.17.1
+ansible-core
 ansible-lint
 molecule
 molecule-plugins[docker]
-# TODO: Remove this once Molecule has been fixed to work with requests >2.31
-requests==2.31.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -109,7 +109,6 @@ referencing==0.35.1
     #   jsonschema-specifications
 requests==2.31.0
     # via
-    #   -r requirements-dev.in
     #   docker
     #   molecule-plugins
 resolvelib==1.0.1


### PR DESCRIPTION
We don't need to explicitly pin these versions anymore, since the packages themselves now have pins to safeguard against these incompatibilities.