### PR TITLE
Update Jenkins version used by Molecule

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -30,6 +30,6 @@
         password: "changeme"
         api_token: "11c8f304eb91ab249386a2d929f28804e5"
     jenkins_user_content: "{{ playbook_dir }}/files/userContent"
-    jenkins_version: "2.452.3"
+    jenkins_version: "2.516.2"
   roles:
     - ableton.jenkins_jcasc

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify
   hosts: all
   vars:
-    jenkins_version_expected: "2.452.3"
+    jenkins_version_expected: "2.516.2"
     test_users:
       alice: "notsecure"
       bob: ""


### PR DESCRIPTION
We have started to see PIMT errors because the latest versions of some
plugins don't support 2.452.x anymore.
